### PR TITLE
Revert "add support for the latest BBB debian 8.2 2015-11-12 image"

### DIFF
--- a/lorank8v1/7d68a/uEnv.patch
+++ b/lorank8v1/7d68a/uEnv.patch
@@ -1,7 +1,0 @@
-47c47,50
-< #cape_disable=capemgr.disable_partno=BB-BONELT-HDMI,BB-BONELT-HDMIN
----
-> cape_disable=capemgr.disable_partno=BB-BONELT-HDMI,BB-BONELT-HDMIN
-> 
-> ##SPI0
-> cape_enable=capemgr.enable_partno=BB-SPIDEV0


### PR DESCRIPTION
Reverts Ideetron/Lorank#1

The syntax is not correct. the new capemgr was listing the 2 spi ports but they were not usable.
The proper patch is 
60a61,62

> ## SPI0
> 
> cape_enable=bone_capemgr.enable_partno=BB-SPIDEV0

It properly creates /dev/spidev1.0 and I can connect to the lora concentrator but it fails a bit later when verifying the calibration firmware version
INFO: [main] Starting the concentrator
ERROR: Version of calibration firmware not expected, actual:0 expected:2
ERROR: [main] failed to start the concentrator

proposing to revert the pr until it's 100% working
