### PR TITLE
Changed cut field parameter to 6, as -f 7 returns nothing.

### DIFF
--- a/lorank8v1/start
+++ b/lorank8v1/start
@@ -8,7 +8,7 @@ while [[ $(ping -c1 google.com 2>&1 | grep " 0% packet loss") == "" ]]; do
 
 # Test if the time has already been set, wait if needed, but not for ever.
 CNT=10
-while [[ $(date | cut -d' ' -f 7) -lt 2016 ]] && [[ $CNT -gt 0 ]]; do
+while [[ $(date | cut -d' ' -f 6) -lt 2016 ]] && [[ $CNT -gt 0 ]]; do
   echo "Concentrator: waiting for clock to be set, ($CNT) ... "
   let CNT=CNT-1
   sleep 15


### PR DESCRIPTION
Changed cut field parameter to 6, as -f 7 returns nothing.

root@lorank8:~/lorank8v1# date
Sat May 14 10:10:04 UTC 2016
root@lorank8:~/lorank8v1# date | cut -d ' ' -f 7

root@lorank8:~/lorank8v1# date | cut -d ' ' -f 6
2016
root@lorank8:~/lorank8v1#
